### PR TITLE
Token reuse timer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,26 +8,38 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ---
 
-## [1.1.0] - (7-20-2020)
+## [2.0.0] - (7-28-2020)
 
 ### Added
 - ATC rpm install/un-install/upgrade
   - will download and cache rpm from official github repo
   - Also right click rpm in folder to install
+  - *** LOCAL CACHE LOCATION? ***
 - json <-> yaml conversion (highlight -> right-click)
 - base64 encode/decode (highlight -> right-click)
-- right-click template/folder to upload FAST template/template Set
-- support remote authentication via logonProvider - PENDING
+- right-click template/folder in explorer view to upload FAST template/template Set
 - Added 'F5-FAST -> Connect!' status bar to provide another way to connect
   - This is especially useful when working in a repo, which is outside the main F5-Fast extension view
+- Added, highlight declaration in editor -> right-click, options for posting AS3/DO/TS declarations
+- support remote authentication via logonProvider - PENDING
+  - Updated config structure (what stores devices details)
+  - Includes right-click option on device to update logonProvider
+    - This provides a list of default options for BIGIP and an option to provide a custom provider for BIGIQ
 
 ### Modified
 - Combined AS3 Tenant and Tasks views
   - This should provider a cleaner and more efficient interface
-  - Now showing number of configured tenants
+  - Now showing number of configured tenants and tasks
+- Updated FAST view
+  - Now includes item counts
+  - This also resulted in more efficient data storage and retrieval
 - Provided feedback and cancellation when connecting to devices
 - Updated examples to include DO github examples
   - Added placeholder for AS3 and linked to AS3 repo issue with pending "examples" folder
+- Auth token now utilized for entire token lifetime
+  - Drastically cut down on network traffic constantly refreshing token for major different functions throughout extension
+  - Added configuration option to show token life countdown in status bar (disabled by default)
+  - If token does expire, next http call will refresh it as needed
 
 Created a git repo for documenting the building of fast templates and a bunch of other things for demo'ing the extension
 

--- a/package.json
+++ b/package.json
@@ -179,6 +179,11 @@
 						"default": true,
 						"description": "Make as3 posts async by default"
 					},
+					"f5.showAuthTokenTimer": {
+						"type": "boolean",
+						"default": false,
+						"description": "Displays a countdown of the auth token lifetime.  Extension will refresh the token as needed with the next call.  This is mainly for visibility/debugging purposes, or for those like a ton of feedback"
+					},
 					"f5.asyncInterval": {
 						"type": "number",
 						"default": 5,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -428,7 +428,6 @@ export function activate(context: vscode.ExtensionContext) {
 
 	context.subscriptions.push(vscode.commands.registerCommand('f5-fast.getInfo', async () => {
 
-		//await ext.mgmtClient.getToken();
 		const resp: any = await ext.mgmtClient.makeRequest(`/mgmt/shared/fast/info`);
 
 		if (ext.settings.previewResponseInUntitledDocument) {
@@ -481,7 +480,6 @@ export function activate(context: vscode.ExtensionContext) {
 
 	context.subscriptions.push(vscode.commands.registerCommand('f5-fast.getApp', async (tenApp) => {
 
-		//await ext.mgmtClient.getToken();
 		const task: any = await ext.mgmtClient.makeRequest(`/mgmt/shared/fast/applications/${tenApp}`);
 
 		if (ext.settings.previewResponseInUntitledDocument) {
@@ -494,7 +492,6 @@ export function activate(context: vscode.ExtensionContext) {
 
 	context.subscriptions.push(vscode.commands.registerCommand('f5-fast.getTask', async (taskId) => {
 
-		//await ext.mgmtClient.getToken();
 		const task: any = await ext.mgmtClient.makeRequest(`/mgmt/shared/fast/tasks/${taskId}`);
 
 		if (ext.settings.previewResponseInUntitledDocument) {
@@ -507,7 +504,6 @@ export function activate(context: vscode.ExtensionContext) {
 
 	context.subscriptions.push(vscode.commands.registerCommand('f5-fast.getTemplate', async (template) => {
 
-		//await ext.mgmtClient.getToken();
 		const resp: any = await ext.mgmtClient.makeRequest(`/mgmt/shared/fast/templates/${template}`);
 
 		if (ext.settings.previewResponseInUntitledDocument) {
@@ -520,7 +516,6 @@ export function activate(context: vscode.ExtensionContext) {
 
 	context.subscriptions.push(vscode.commands.registerCommand('f5-fast.getTemplateSets', async (set) => {
 
-		//await ext.mgmtClient.getToken();
 		const resp: any = await ext.mgmtClient.makeRequest(`/mgmt/shared/fast/templatesets/${set}`);
 
 		if (ext.settings.previewResponseInUntitledDocument) {
@@ -790,7 +785,6 @@ export function activate(context: vscode.ExtensionContext) {
 		// set blank value if not defined -> get all tenants dec
 		tenant = tenant ? tenant : '';
 
-		//await ext.mgmtClient.getToken();
 		const resp: any = await ext.mgmtClient.makeRequest(`/mgmt/shared/appsvcs/declare/${tenant}`);
 		utils.displayJsonInEditor(resp.data);
 
@@ -811,7 +805,7 @@ export function activate(context: vscode.ExtensionContext) {
 			location: vscode.ProgressLocation.Notification,
 			title: `Deleting ${tenant.label} Tenant`
 		}, async (progress) => {
-			//await ext.mgmtClient.getToken();
+			
 			const resp: any = await ext.mgmtClient.makeRequest(`/mgmt/shared/appsvcs/declare/${tenant.label}`, {
 				method: 'DELETE'
 			});
@@ -830,7 +824,7 @@ export function activate(context: vscode.ExtensionContext) {
 			location: vscode.ProgressLocation.Notification,
 			title: `Getting AS3 Task`
 		}, async () => {
-			//await ext.mgmtClient.getToken();
+
 			const resp: any = await ext.mgmtClient.makeRequest(`/mgmt/shared/appsvcs/task/${id}`);
 			utils.displayJsonInEditor(resp.data);
 		});
@@ -1003,14 +997,12 @@ export function activate(context: vscode.ExtensionContext) {
 
 
 	context.subscriptions.push(vscode.commands.registerCommand('f5-ts.info', async () => {
-		//await ext.mgmtClient.getToken();
 		const resp: any = await ext.mgmtClient.makeRequest('/mgmt/shared/telemetry/info');
 		utils.displayJsonInEditor(resp.data);
 	}));
 
 
 	context.subscriptions.push(vscode.commands.registerCommand('f5-ts.getDec', async () => {
-		//await ext.mgmtClient.getToken();
 		await vscode.window.withProgress({
 			location: vscode.ProgressLocation.Notification,
 			title: `Getting TS Dec`
@@ -1041,7 +1033,6 @@ export function activate(context: vscode.ExtensionContext) {
 			location: vscode.ProgressLocation.Notification,
 			title: `Posting TS Dec`
 		}, async () => {
-			//await ext.mgmtClient.getToken();
 			const resp: any = await ext.mgmtClient.makeRequest(`/mgmt/shared/telemetry/declare`, {
 				method: 'POST',
 				body: JSON.parse(text)
@@ -1098,7 +1089,6 @@ export function activate(context: vscode.ExtensionContext) {
 			location: vscode.ProgressLocation.Notification,
 			title: `Getting DO Dec`
 		}, async () => {
-			//await ext.mgmtClient.getToken();
 			const resp: any = await ext.mgmtClient.makeRequest(`/mgmt/shared/declarative-onboarding/`);
 			utils.displayJsonInEditor(resp.data.declaration);
 		});
@@ -1136,7 +1126,6 @@ export function activate(context: vscode.ExtensionContext) {
 			location: vscode.ProgressLocation.Notification,
 			title: `Getting DO Inspect`
 		}, async () => {
-			//await ext.mgmtClient.getToken();
 			const resp: any = await ext.mgmtClient.makeRequest(`/mgmt/shared/declarative-onboarding/inspect`);
 			utils.displayJsonInEditor(resp.data);
 		}); 
@@ -1151,7 +1140,6 @@ export function activate(context: vscode.ExtensionContext) {
 			location: vscode.ProgressLocation.Notification,
 			title: `Getting DO Tasks`
 		}, async () => {
-			//await ext.mgmtClient.getToken();
 			const resp: any = await ext.mgmtClient.makeRequest(`/mgmt/shared/declarative-onboarding/task`);
 			utils.displayJsonInEditor(resp.data);
 		});

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -94,12 +94,16 @@ export function activate(context: vscode.ExtensionContext) {
 		console.log('selected device', device);
 
 		// clear status bars before new connect
-		utils.setHostStatusBar();
-		utils.setHostnameBar();
-		utils.setFastBar();
-		utils.setAS3Bar();
-		utils.setDOBar();
-		utils.setTSBar();	
+		// utils.setHostStatusBar();
+		// utils.setHostnameBar();
+		// utils.setFastBar();
+		// utils.setAS3Bar();
+		// utils.setDOBar();
+		// utils.setTSBar();	
+
+		if(ext.mgmtClient) {
+			ext.mgmtClient.disconnect();
+		}
 
 		type devObj = {
 			device: string,
@@ -163,7 +167,7 @@ export function activate(context: vscode.ExtensionContext) {
 			throw new Error('no hosts in configuration');
 		}
 
-		await ext.mgmtClient.getToken();
+		//await ext.mgmtClient.getToken();
 		const resp: any = await ext.mgmtClient.makeRequest('/mgmt/shared/identified-devices/config/device-info');
 
 		// const password: string = await utils.getPassword(device);
@@ -174,15 +178,19 @@ export function activate(context: vscode.ExtensionContext) {
 
 	context.subscriptions.push(vscode.commands.registerCommand('f5.disconnect', () => {
 
-		// clear status bars
-		utils.setHostStatusBar();
-		utils.setHostnameBar();
-		utils.setFastBar();
-		utils.setAS3Bar();
-		utils.setDOBar();
-		utils.setTSBar();
+		if(ext.mgmtClient) {
+			ext.mgmtClient.disconnect();
+		}
 
-		ext.connectBar.show();
+		// clear status bars
+		// utils.setHostStatusBar();
+		// utils.setHostnameBar();
+		// utils.setFastBar();
+		// utils.setAS3Bar();
+		// utils.setDOBar();
+		// utils.setTSBar();
+
+		// ext.connectBar.show();
 
 		// return vscode.window.showInformationMessage('clearing selected bigip and status bar details');
 	}));
@@ -191,12 +199,16 @@ export function activate(context: vscode.ExtensionContext) {
 		console.log('CLEARING KEYTAR PASSWORD CACHE');
 
 		// clear status bars 
-		utils.setHostStatusBar();
-		utils.setHostnameBar();
-		utils.setFastBar();
-		utils.setAS3Bar();
-		utils.setDOBar();
-		utils.setTSBar();
+		// utils.setHostStatusBar();
+		// utils.setHostnameBar();
+		// utils.setFastBar();
+		// utils.setAS3Bar();
+		// utils.setDOBar();
+		// utils.setTSBar();
+
+		if(ext.mgmtClient) {
+			ext.mgmtClient.disconnect();
+		}
 
 		// get list of items in keytar for the 'f5Hosts' service
 		await ext.keyTar.findCredentials('f5Hosts').then( list => {
@@ -359,7 +371,7 @@ export function activate(context: vscode.ExtensionContext) {
 			throw new Error('Remote Command inputBox cancelled');
 		}
 
-		await ext.mgmtClient.getToken();
+		//await ext.mgmtClient.getToken();
 		const resp: any = await ext.mgmtClient.makeRequest(`/mgmt/tm/util/bash`, {
 			method: 'POST',
 			body: {
@@ -462,7 +474,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 	context.subscriptions.push(vscode.commands.registerCommand('f5-fast.getInfo', async () => {
 
-		await ext.mgmtClient.getToken();
+		//await ext.mgmtClient.getToken();
 		const resp: any = await ext.mgmtClient.makeRequest(`/mgmt/shared/fast/info`);
 
 		if (ext.settings.previewResponseInUntitledDocument) {
@@ -515,7 +527,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 	context.subscriptions.push(vscode.commands.registerCommand('f5-fast.getApp', async (tenApp) => {
 
-		await ext.mgmtClient.getToken();
+		//await ext.mgmtClient.getToken();
 		const task: any = await ext.mgmtClient.makeRequest(`/mgmt/shared/fast/applications/${tenApp}`);
 
 		if (ext.settings.previewResponseInUntitledDocument) {
@@ -528,7 +540,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 	context.subscriptions.push(vscode.commands.registerCommand('f5-fast.getTask', async (taskId) => {
 
-		await ext.mgmtClient.getToken();
+		//await ext.mgmtClient.getToken();
 		const task: any = await ext.mgmtClient.makeRequest(`/mgmt/shared/fast/tasks/${taskId}`);
 
 		if (ext.settings.previewResponseInUntitledDocument) {
@@ -541,7 +553,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 	context.subscriptions.push(vscode.commands.registerCommand('f5-fast.getTemplate', async (template) => {
 
-		await ext.mgmtClient.getToken();
+		//await ext.mgmtClient.getToken();
 		const resp: any = await ext.mgmtClient.makeRequest(`/mgmt/shared/fast/templates/${template}`);
 
 		if (ext.settings.previewResponseInUntitledDocument) {
@@ -554,7 +566,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 	context.subscriptions.push(vscode.commands.registerCommand('f5-fast.getTemplateSets', async (set) => {
 
-		await ext.mgmtClient.getToken();
+		//await ext.mgmtClient.getToken();
 		const resp: any = await ext.mgmtClient.makeRequest(`/mgmt/shared/fast/templatesets/${set}`);
 
 		if (ext.settings.previewResponseInUntitledDocument) {
@@ -824,7 +836,7 @@ export function activate(context: vscode.ExtensionContext) {
 		// set blank value if not defined -> get all tenants dec
 		tenant = tenant ? tenant : '';
 
-		await ext.mgmtClient.getToken();
+		//await ext.mgmtClient.getToken();
 		const resp: any = await ext.mgmtClient.makeRequest(`/mgmt/shared/appsvcs/declare/${tenant}`);
 		utils.displayJsonInEditor(resp.data);
 
@@ -845,7 +857,7 @@ export function activate(context: vscode.ExtensionContext) {
 			location: vscode.ProgressLocation.Notification,
 			title: `Deleting ${tenant.label} Tenant`
 		}, async (progress) => {
-			await ext.mgmtClient.getToken();
+			//await ext.mgmtClient.getToken();
 			const resp: any = await ext.mgmtClient.makeRequest(`/mgmt/shared/appsvcs/declare/${tenant.label}`, {
 				method: 'DELETE'
 			});
@@ -864,7 +876,7 @@ export function activate(context: vscode.ExtensionContext) {
 			location: vscode.ProgressLocation.Notification,
 			title: `Getting AS3 Task`
 		}, async () => {
-			await ext.mgmtClient.getToken();
+			//await ext.mgmtClient.getToken();
 			const resp: any = await ext.mgmtClient.makeRequest(`/mgmt/shared/appsvcs/task/${id}`);
 			utils.displayJsonInEditor(resp.data);
 		});
@@ -1042,14 +1054,14 @@ export function activate(context: vscode.ExtensionContext) {
 
 
 	context.subscriptions.push(vscode.commands.registerCommand('f5-ts.info', async () => {
-		await ext.mgmtClient.getToken();
+		//await ext.mgmtClient.getToken();
 		const resp: any = await ext.mgmtClient.makeRequest('/mgmt/shared/telemetry/info');
 		utils.displayJsonInEditor(resp.data);
 	}));
 
 
 	context.subscriptions.push(vscode.commands.registerCommand('f5-ts.getDec', async () => {
-		await ext.mgmtClient.getToken();
+		//await ext.mgmtClient.getToken();
 		await vscode.window.withProgress({
 			location: vscode.ProgressLocation.Notification,
 			title: `Getting TS Dec`
@@ -1080,7 +1092,7 @@ export function activate(context: vscode.ExtensionContext) {
 			location: vscode.ProgressLocation.Notification,
 			title: `Posting TS Dec`
 		}, async () => {
-			await ext.mgmtClient.getToken();
+			//await ext.mgmtClient.getToken();
 			const resp: any = await ext.mgmtClient.makeRequest(`/mgmt/shared/telemetry/declare`, {
 				method: 'POST',
 				body: JSON.parse(text)
@@ -1137,7 +1149,7 @@ export function activate(context: vscode.ExtensionContext) {
 			location: vscode.ProgressLocation.Notification,
 			title: `Getting DO Dec`
 		}, async () => {
-			await ext.mgmtClient.getToken();
+			//await ext.mgmtClient.getToken();
 			const resp: any = await ext.mgmtClient.makeRequest(`/mgmt/shared/declarative-onboarding/`);
 			utils.displayJsonInEditor(resp.data.declaration);
 		});
@@ -1175,7 +1187,7 @@ export function activate(context: vscode.ExtensionContext) {
 			location: vscode.ProgressLocation.Notification,
 			title: `Getting DO Inspect`
 		}, async () => {
-			await ext.mgmtClient.getToken();
+			//await ext.mgmtClient.getToken();
 			const resp: any = await ext.mgmtClient.makeRequest(`/mgmt/shared/declarative-onboarding/inspect`);
 			utils.displayJsonInEditor(resp.data);
 		}); 
@@ -1190,7 +1202,7 @@ export function activate(context: vscode.ExtensionContext) {
 			location: vscode.ProgressLocation.Notification,
 			title: `Getting DO Tasks`
 		}, async () => {
-			await ext.mgmtClient.getToken();
+			//await ext.mgmtClient.getToken();
 			const resp: any = await ext.mgmtClient.makeRequest(`/mgmt/shared/declarative-onboarding/task`);
 			utils.displayJsonInEditor(resp.data);
 		});

--- a/src/treeViewsProviders/as3TasksTreeProvider.ts
+++ b/src/treeViewsProviders/as3TasksTreeProvider.ts
@@ -28,7 +28,7 @@ export class AS3TreeProvider implements vscode.TreeDataProvider<AS3Item> {
 		}
 
 		// await ext.mgmtClient.token();
-		const rp = await ext.mgmtClient.getToken();
+		//const rp = await ext.mgmtClient.getToken();
 		const resp: any = await ext.mgmtClient.makeRequest(`/mgmt/shared/appsvcs/task/`);
 
 		const taskItems = resp.data.items.map((item:any) => {

--- a/src/treeViewsProviders/as3TenantTreeProvider.ts
+++ b/src/treeViewsProviders/as3TenantTreeProvider.ts
@@ -48,7 +48,6 @@ export class AS3TenantTreeProvider implements vscode.TreeDataProvider<AS3item> {
 			/**
 			 * todo:  look at moving this to the refresh function, might cut back on how often it gets called
 			 */
-			//await ext.mgmtClient.getToken();
 			await this.getTenants(); // refresh tenant information
 			await this.getTasks();	// refresh tasks information
 

--- a/src/treeViewsProviders/as3TenantTreeProvider.ts
+++ b/src/treeViewsProviders/as3TenantTreeProvider.ts
@@ -48,7 +48,7 @@ export class AS3TenantTreeProvider implements vscode.TreeDataProvider<AS3item> {
 			/**
 			 * todo:  look at moving this to the refresh function, might cut back on how often it gets called
 			 */
-			await ext.mgmtClient.getToken();
+			//await ext.mgmtClient.getToken();
 			await this.getTenants(); // refresh tenant information
 			await this.getTasks();	// refresh tasks information
 

--- a/src/treeViewsProviders/fastTreeProvider.ts
+++ b/src/treeViewsProviders/fastTreeProvider.ts
@@ -114,7 +114,6 @@ export class FastTemplatesTreeProvider implements vscode.TreeDataProvider<FastTr
 
 		} else {
 
-		//await ext.mgmtClient.getToken();
 		// gather all necessary details
 		// looking for ways to do this async
 		await this.getApps();

--- a/src/treeViewsProviders/fastTreeProvider.ts
+++ b/src/treeViewsProviders/fastTreeProvider.ts
@@ -114,7 +114,7 @@ export class FastTemplatesTreeProvider implements vscode.TreeDataProvider<FastTr
 
 		} else {
 
-		await ext.mgmtClient.getToken();
+		//await ext.mgmtClient.getToken();
 		// gather all necessary details
 		// looking for ways to do this async
 		await this.getApps();

--- a/src/utils/f5Api.ts
+++ b/src/utils/f5Api.ts
@@ -381,8 +381,6 @@ export async function postDoDec(dec: Dec) {
             return new Error(`User canceled the async post`);
         });
         
-        //await ext.mgmtClient.getToken();
-
         // post initial dec
         let resp: any = await ext.mgmtClient.makeRequest(`/mgmt/shared/declarative-onboarding/`, {
             method: 'POST',
@@ -575,7 +573,6 @@ export async function postAS3Dec(postParam: string = '', dec: object) {
         });
 
         // post initial dec
-        //await ext.mgmtClient.getToken();
         let resp: any = await ext.mgmtClient.makeRequest(`/mgmt/shared/appsvcs/declare?${postParam}`, {
             method: 'POST',
             body: dec

--- a/src/utils/f5Api.ts
+++ b/src/utils/f5Api.ts
@@ -381,7 +381,7 @@ export async function postDoDec(dec: Dec) {
             return new Error(`User canceled the async post`);
         });
         
-        await ext.mgmtClient.getToken();
+        //await ext.mgmtClient.getToken();
 
         // post initial dec
         let resp: any = await ext.mgmtClient.makeRequest(`/mgmt/shared/declarative-onboarding/`, {
@@ -575,7 +575,7 @@ export async function postAS3Dec(postParam: string = '', dec: object) {
         });
 
         // post initial dec
-        await ext.mgmtClient.getToken();
+        //await ext.mgmtClient.getToken();
         let resp: any = await ext.mgmtClient.makeRequest(`/mgmt/shared/appsvcs/declare?${postParam}`, {
             method: 'POST',
             body: dec

--- a/src/utils/f5DeviceClient.ts
+++ b/src/utils/f5DeviceClient.ts
@@ -242,7 +242,11 @@ export class MgmtClient {
         this._tmrBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
         this._tmrBar.tooltip = 'F5 AuthToken Timer';
         this._tmrBar.color = 'silver';
-        this._tmrBar.show();
+
+        const makeVisible = vscode.workspace.getConfiguration().get('f5.showAuthTokenTimer');
+        if(makeVisible) {
+            this._tmrBar.show();
+        }
 
         let intervalId = setInterval(() => {
             this._tmrBar.text = `${this._tokenTimeout}`;

--- a/src/utils/f5FastApi.ts
+++ b/src/utils/f5FastApi.ts
@@ -24,7 +24,6 @@ export async function deployFastApp(dec: object) {
             return new Error(`User canceled the async post`);
         });
 
-        //await ext.mgmtClient.getToken();
         // post initial dec
         let response: any = await ext.mgmtClient.makeRequest(`/mgmt/shared/fast/applications`, {
             method: 'POST',
@@ -80,7 +79,6 @@ export async function delTenApp(tenApp: string) {
         title: `Deleting FAST App: ${tenApp}`
     }, async (progress) => {
 
-        //await ext.mgmtClient.getToken();
         let response: any = await ext.mgmtClient.makeRequest(`/mgmt/shared/fast/applications/${tenApp}`, {
             method: 'DELETE'
         });
@@ -125,7 +123,6 @@ export async function delTempSet(tempSet: string) {
         title: `Deleting FAST Template Set: ${tempSet}`
     }, async (progress) => {
 
-        //await ext.mgmtClient.getToken();
         let response: any = await ext.mgmtClient.makeRequest(`/mgmt/shared/fast/templatesets/${tempSet}`, {
             method: 'DELETE'
         });

--- a/src/utils/f5FastApi.ts
+++ b/src/utils/f5FastApi.ts
@@ -24,7 +24,7 @@ export async function deployFastApp(dec: object) {
             return new Error(`User canceled the async post`);
         });
 
-        await ext.mgmtClient.getToken();
+        //await ext.mgmtClient.getToken();
         // post initial dec
         let response: any = await ext.mgmtClient.makeRequest(`/mgmt/shared/fast/applications`, {
             method: 'POST',
@@ -80,7 +80,7 @@ export async function delTenApp(tenApp: string) {
         title: `Deleting FAST App: ${tenApp}`
     }, async (progress) => {
 
-        await ext.mgmtClient.getToken();
+        //await ext.mgmtClient.getToken();
         let response: any = await ext.mgmtClient.makeRequest(`/mgmt/shared/fast/applications/${tenApp}`, {
             method: 'DELETE'
         });
@@ -125,7 +125,7 @@ export async function delTempSet(tempSet: string) {
         title: `Deleting FAST Template Set: ${tempSet}`
     }, async (progress) => {
 
-        await ext.mgmtClient.getToken();
+        //await ext.mgmtClient.getToken();
         let response: any = await ext.mgmtClient.makeRequest(`/mgmt/shared/fast/templatesets/${tempSet}`, {
             method: 'DELETE'
         });

--- a/src/utils/f5FastUtils.ts
+++ b/src/utils/f5FastUtils.ts
@@ -100,8 +100,6 @@ export async function zipPostTemplate (doc: string) {
         // console.log(package1);
         // console.log('zipOut', zipOut);
 
-        //await ext.mgmtClient.getToken();
-
         //f5-sdk-js version
         progress.report({ message: `Uploading Template`});
         await new Promise(resolve => { setTimeout(resolve, (1000)); });
@@ -189,13 +187,6 @@ export async function zipPostTempSet (folder: string) {
         /**
          * if we have gotten this far, it's time to get ready for POST
          */
-
-        // const device = ext.hostStatusBar.text;
-        // const password = await utils.getPassword(device);
-        // const [username, host] = device.split('@');
-        // const authToken = await getAuthToken(host, username, password);
-
-        //await ext.mgmtClient.getToken();
 
         // //f5-sdk-js version
         progress.report({ message: `Uploading Template set`});

--- a/src/utils/f5FastUtils.ts
+++ b/src/utils/f5FastUtils.ts
@@ -100,7 +100,7 @@ export async function zipPostTemplate (doc: string) {
         // console.log(package1);
         // console.log('zipOut', zipOut);
 
-        await ext.mgmtClient.getToken();
+        //await ext.mgmtClient.getToken();
 
         //f5-sdk-js version
         progress.report({ message: `Uploading Template`});
@@ -195,7 +195,7 @@ export async function zipPostTempSet (folder: string) {
         // const [username, host] = device.split('@');
         // const authToken = await getAuthToken(host, username, password);
 
-        await ext.mgmtClient.getToken();
+        //await ext.mgmtClient.getToken();
 
         // //f5-sdk-js version
         progress.report({ message: `Uploading Template set`});

--- a/src/utils/rpmMgmt.ts
+++ b/src/utils/rpmMgmt.ts
@@ -41,7 +41,6 @@ export async function installedRPMs () {
      *      is being gathered and waiting for user to select...
      */
     
-    //await ext.mgmtClient.getToken();   // refresh token
     // start installed pkgs query
     const query: any = await ext.mgmtClient.makeRequest(PKG_MGMT_URI, {
             method: 'POST',
@@ -245,8 +244,6 @@ export async function rpmInstaller (rpm: string) {
         // get rpm name from full file path
         const rpmName = path.basename(rpm);
 
-
-        //await ext.mgmtClient.getToken();   // refresh auth token
         // let rpms finish downloading...
         await new Promise(resolve => { setTimeout(resolve, 2000); });
 

--- a/src/utils/rpmMgmt.ts
+++ b/src/utils/rpmMgmt.ts
@@ -41,7 +41,7 @@ export async function installedRPMs () {
      *      is being gathered and waiting for user to select...
      */
     
-    await ext.mgmtClient.getToken();   // refresh token
+    //await ext.mgmtClient.getToken();   // refresh token
     // start installed pkgs query
     const query: any = await ext.mgmtClient.makeRequest(PKG_MGMT_URI, {
             method: 'POST',
@@ -246,7 +246,7 @@ export async function rpmInstaller (rpm: string) {
         const rpmName = path.basename(rpm);
 
 
-        await ext.mgmtClient.getToken();   // refresh auth token
+        //await ext.mgmtClient.getToken();   // refresh auth token
         // let rpms finish downloading...
         await new Promise(resolve => { setTimeout(resolve, 2000); });
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,10 +1,6 @@
 import * as vscode from 'vscode';
 import { ext } from '../extensionVariables';
 
-// import { F5Api } from './f5Api';
-
-// const f5API = new f5Api();
-
 /**
  * Host Connectivity Status Bar
  * Feed it text, it will show up
@@ -228,20 +224,4 @@ export async function getPassword(device: string): Promise<any> {
     }
     // console.log(`PASSWORD BOUT TO BE RETURNED!!! - ${password}`);
     return password;
-}
-
-export function setMemento(key:string, value: string) {
-    ext.context.globalState.update(key, value);
-}
-
-export function getMemento(key:string) {
-    return ext.context.globalState.get(key);
-}
-
-export function setMementoW(key:string, value: string) {
-    ext.context.workspaceState.update(key, value);
-}
-
-export function getMementoW(key:string) {
-    return ext.context.workspaceState.get(key);
 }


### PR DESCRIPTION
Reworked f5DeviceClient(mgmtClient) to store entire auth token details, including token lifetime (default 1200).

Added token lifetime countdown that clears all token details once it hits <=0.

Updated mgmtClient makeRequest (main HTTPS caller) function to check for valid auth token, and get one if not available (this should kick off a new timer).

Updated device disconnect/reconnect flows to accommodate new functionality.

This greatly reduced the amount of times the user/pass is sent across the network (although SSL encrypted) and removed any abuse of the authToken service on the destination device (from frequent token requests)